### PR TITLE
Refactor logging to support debug-level filtering and early startup logs

### DIFF
--- a/plugin/src/main/java/com/beepsterr/betterkeepinventory/Events/OnPlayerDeath.java
+++ b/plugin/src/main/java/com/beepsterr/betterkeepinventory/Events/OnPlayerDeath.java
@@ -28,7 +28,7 @@ public class OnPlayerDeath  implements Listener {
         Player ply = event.getEntity();
         NestedLogBuilder nlb = new NestedLogBuilder(Level.FINE);
 
-        nlb.log("Player" + ply.getName() + " (" + ply.getUniqueId() + ") died.");
+        nlb.log("Player " + ply.getName() + " (" + ply.getUniqueId() + ") died.");
         nlb.spacer();
         nlb.cont("Phase 1/2 (Death)");
         nlb.cont("World: " + ply.getWorld().getName() + " ( KI: " + ply.getWorld().getGameRuleValue(GameRule.KEEP_INVENTORY) + ")");

--- a/plugin/src/main/java/com/beepsterr/betterkeepinventory/Events/OnPlayerDeath.java
+++ b/plugin/src/main/java/com/beepsterr/betterkeepinventory/Events/OnPlayerDeath.java
@@ -26,7 +26,7 @@ public class OnPlayerDeath  implements Listener {
     public void onPlayerDeath(PlayerDeathEvent event) {
 
         Player ply = event.getEntity();
-        NestedLogBuilder nlb = new NestedLogBuilder(Level.INFO);
+        NestedLogBuilder nlb = new NestedLogBuilder(Level.FINE);
 
         nlb.log("Player" + ply.getName() + " (" + ply.getUniqueId() + ") died.");
         nlb.spacer();

--- a/plugin/src/main/java/com/beepsterr/betterkeepinventory/Events/OnPlayerRespawn.java
+++ b/plugin/src/main/java/com/beepsterr/betterkeepinventory/Events/OnPlayerRespawn.java
@@ -11,6 +11,8 @@ import org.bukkit.event.entity.PlayerDeathEvent;
 import org.bukkit.event.player.PlayerJoinEvent;
 import org.bukkit.event.player.PlayerRespawnEvent;
 
+import java.util.logging.Level;
+
 public class OnPlayerRespawn implements Listener {
 
     BetterKeepInventory plugin;
@@ -24,7 +26,7 @@ public class OnPlayerRespawn implements Listener {
     public void onPlayerRespawn(PlayerRespawnEvent event) {
 
         Player ply = event.getPlayer();
-        NestedLogBuilder nlb = new NestedLogBuilder();
+        NestedLogBuilder nlb = new NestedLogBuilder(Level.FINE);
 
         nlb.log("Player" + ply.getName() + " (" + ply.getUniqueId() + ") died.");
         nlb.spacer();

--- a/plugin/src/main/java/com/beepsterr/betterkeepinventory/Events/OnPlayerRespawn.java
+++ b/plugin/src/main/java/com/beepsterr/betterkeepinventory/Events/OnPlayerRespawn.java
@@ -28,7 +28,7 @@ public class OnPlayerRespawn implements Listener {
         Player ply = event.getPlayer();
         NestedLogBuilder nlb = new NestedLogBuilder(Level.FINE);
 
-        nlb.log("Player" + ply.getName() + " (" + ply.getUniqueId() + ") died.");
+        nlb.log("Player " + ply.getName() + " (" + ply.getUniqueId() + ") respawned.");
         nlb.spacer();
         nlb.cont("Phase 2/2 (Respawn)");
         nlb.cont("World: " + ply.getWorld().getName());

--- a/plugin/src/main/java/com/beepsterr/betterkeepinventory/Library/NestedLogBuilder.java
+++ b/plugin/src/main/java/com/beepsterr/betterkeepinventory/Library/NestedLogBuilder.java
@@ -41,6 +41,23 @@ public class NestedLogBuilder implements LoggerInterface {
         return prefix.toString();
     }
 
+    // Warnings and errors always reach the console; informational output only when debug is on.
+    // Before Config finishes loading (startup), log everything so admins can see early failures.
+    private boolean shouldPrint(Level level){
+        if(level.intValue() >= Level.WARNING.intValue()){
+            return true;
+        }
+        Config cfg = Config.getInstance();
+        return cfg == null || cfg.isDebug();
+    }
+
+    private void print(Level level, String msg){
+        if(shouldPrint(level)){
+            logger.log(level, msg);
+        }
+        BetterKeepInventory.getInstance().debugger.AddLine(msg);
+    }
+
     public void SetDepth(int d){
         depth = d;
     }
@@ -59,8 +76,7 @@ public class NestedLogBuilder implements LoggerInterface {
         }else{
             msg += title;
         }
-        logger.log(this.level, msg);
-        BetterKeepInventory.getInstance().debugger.AddLine(msg);
+        print(this.level, msg);
         depth++;
 
     }
@@ -68,39 +84,36 @@ public class NestedLogBuilder implements LoggerInterface {
     public void parent(){
         if(depth > 0){
             String msg = getPrefix().replace(LOG_ENTRY, LOG_END);
-            logger.log(this.level, msg);
+            if(shouldPrint(this.level)){
+                logger.log(this.level, msg);
+            }
             depth--;
         }
     }
 
     public void log(Level level, String message){
         String msg = getPrefix() + " " + message;
-        logger.log(level, msg);
-        BetterKeepInventory.getInstance().debugger.AddLine(msg);
+        print(level, msg);
     }
 
     public void log(String message){
         String msg = getPrefix() + " " + message;
-        logger.log(this.level, msg);
-        BetterKeepInventory.getInstance().debugger.AddLine(msg);
+        print(this.level, msg);
     }
 
     public void cont(Level level, String message){
         String msg = getPrefix().replace(LOG_ENTRY, LOG_SPACER) + " " + message;
-        logger.log(level, msg);
-        BetterKeepInventory.getInstance().debugger.AddLine(msg);
+        print(level, msg);
     }
 
     public void cont(String message){
         String msg = getPrefix().replace(LOG_ENTRY, LOG_SPACER) + " " + message;
-        logger.log(this.level, msg);
-        BetterKeepInventory.getInstance().debugger.AddLine(msg);
+        print(this.level, msg);
     }
 
     public void spacer(){
         String msg = getPrefix().replace(LOG_ENTRY, LOG_SPACER) + " ";
-        logger.log(this.level, msg);
-        BetterKeepInventory.getInstance().debugger.AddLine(msg);
+        print(this.level, msg);
     }
 
     public void end(){
@@ -108,8 +121,7 @@ public class NestedLogBuilder implements LoggerInterface {
             parent();
         }
         String msg = getPrefix().replace(LOG_ENTRY, LOG_END);
-        logger.log(this.level, msg);
-        BetterKeepInventory.getInstance().debugger.AddLine(msg);
+        print(this.level, msg);
     }
 
 }

--- a/plugin/src/main/java/com/beepsterr/betterkeepinventory/Library/NestedLogBuilder.java
+++ b/plugin/src/main/java/com/beepsterr/betterkeepinventory/Library/NestedLogBuilder.java
@@ -41,10 +41,10 @@ public class NestedLogBuilder implements LoggerInterface {
         return prefix.toString();
     }
 
-    // Warnings and errors always reach the console; informational output only when debug is on.
-    // Before Config finishes loading (startup), log everything so admins can see early failures.
+    // INFO and above always reach the console; sub-INFO (FINE/FINER/FINEST) only when debug is on.
+    // Before Config finishes loading (startup), fall back to "print" so early failures are visible.
     private boolean shouldPrint(Level level){
-        if(level.intValue() >= Level.WARNING.intValue()){
+        if(level.intValue() >= Level.INFO.intValue()){
             return true;
         }
         Config cfg = Config.getInstance();
@@ -53,7 +53,10 @@ public class NestedLogBuilder implements LoggerInterface {
 
     private void print(Level level, String msg){
         if(shouldPrint(level)){
-            logger.log(level, msg);
+            // Bukkit's plugin logger inherits the root INFO threshold, so emit sub-INFO
+            // messages at INFO when debug is enabled — otherwise JUL would drop them silently.
+            Level emitAt = level.intValue() < Level.INFO.intValue() ? Level.INFO : level;
+            logger.log(emitAt, msg);
         }
         BetterKeepInventory.getInstance().debugger.AddLine(msg);
     }
@@ -84,9 +87,7 @@ public class NestedLogBuilder implements LoggerInterface {
     public void parent(){
         if(depth > 0){
             String msg = getPrefix().replace(LOG_ENTRY, LOG_END);
-            if(shouldPrint(this.level)){
-                logger.log(this.level, msg);
-            }
+            print(this.level, msg);
             depth--;
         }
     }


### PR DESCRIPTION
## Summary
This PR refactors the `NestedLogBuilder` logging system to intelligently filter log levels based on debug configuration and handle early startup logs before the Config is fully initialized.

## Key Changes
- **Added `shouldPrint()` method**: Implements smart filtering where INFO and above always reach the console, while sub-INFO levels (FINE/FINER/FINEST) only print when debug mode is enabled. Falls back gracefully during startup when Config hasn't loaded yet.
- **Added `print()` method**: Centralizes all logging output, handling the Bukkit logger's INFO threshold limitation by emitting sub-INFO messages at INFO level when debug is enabled, preventing silent drops by Java's logging framework.
- **Refactored all logging calls**: Replaced direct `logger.log()` and `debugger.AddLine()` calls throughout the class with the new `print()` method for consistency and maintainability.
- **Updated event handlers**: Changed `OnPlayerDeath` and `OnPlayerRespawn` to use `Level.FINE` instead of `Level.INFO`, allowing these detailed logs to be filtered based on debug configuration rather than always appearing in console output.

## Implementation Details
- The `shouldPrint()` method safely handles the case where `Config.getInstance()` returns null during early startup, ensuring critical logs are visible even before configuration is fully loaded.
- The level adjustment in `print()` works around Bukkit's plugin logger inheriting the root Java logging threshold, ensuring debug logs are actually visible when debug mode is enabled.
- All logging now flows through a single code path, making future logging enhancements easier to implement consistently.

https://claude.ai/code/session_01LtkPdxNfzM1jTFM6c7nFUz