### PR TITLE
Fix message sending to respect disabled messages

### DIFF
--- a/plugin/src/main/java/com/beepsterr/betterkeepinventory/Library/Config.java
+++ b/plugin/src/main/java/com/beepsterr/betterkeepinventory/Library/Config.java
@@ -143,9 +143,8 @@ public class Config {
         String message = getMessage(key, replacements);
         if(!message.isEmpty()){
             ply.sendMessage(message);
-        }else{
-            ply.sendMessage(key);
         }
+        // An empty message means the user intentionally disabled it, so send nothing.
     }
 
     public void LoadMessages(BetterKeepInventory plugin) throws IOException {


### PR DESCRIPTION
## Summary
Updated the message sending logic to properly handle disabled messages by not falling back to sending the message key when a message is intentionally disabled.

## Key Changes
- Removed the fallback behavior that sent the message key when a configured message was empty
- Added clarifying comment explaining that empty messages represent intentionally disabled features
- This prevents confusing key names from being sent to players when messages are disabled in the configuration

## Implementation Details
Previously, if a message was not configured or was empty, the plugin would send the raw message key (e.g., "message.key.name") to the player. This change respects the user's intent when they disable a message by sending nothing instead of a fallback key string.

https://claude.ai/code/session_01Bh2fhzWz8GwAFZmMRTbiid